### PR TITLE
Revert "Bump rollup-plugin-scss from 3.0.0 to 4.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "npm-run-all": "^4.1.5",
         "rollup": "^3.9.1",
         "rollup-plugin-copy": "^3.4.0",
-        "rollup-plugin-scss": "^4.0.0",
+        "rollup-plugin-scss": "^3.0.0",
         "sass": "^1.57.1"
       },
       "devDependencies": {
@@ -3839,14 +3839,6 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/govuk-prototype-rig/node_modules/rollup-plugin-scss": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
-      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
-      "dependencies": {
-        "rollup-pluginutils": "^2.3.3"
-      }
-    },
     "node_modules/govuk-prototype-wizard": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/govuk-prototype-wizard/-/govuk-prototype-wizard-0.2.0.tgz",
@@ -7458,9 +7450,9 @@
       }
     },
     "node_modules/rollup-plugin-scss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-4.0.0.tgz",
-      "integrity": "sha512-wxasNXDYC2m+fDxCMgK00WebVWYmeFvShyNABmjvSJZ6D1/SepwqFeaMFMQromveI79gfvb64yJjiZZxSZxEIA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
+      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
       "dependencies": {
         "rollup-pluginutils": "^2.3.3"
       }
@@ -12090,14 +12082,6 @@
               "requires": {
                 "argparse": "^2.0.1"
               }
-            },
-            "rollup-plugin-scss": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
-              "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
-              "requires": {
-                "rollup-pluginutils": "^2.3.3"
-              }
             }
           }
         },
@@ -12107,14 +12091,6 @@
           "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
           "requires": {
             "argparse": "^2.0.1"
-          }
-        },
-        "rollup-plugin-scss": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
-          "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
-          "requires": {
-            "rollup-pluginutils": "^2.3.3"
           }
         }
       }
@@ -14780,9 +14756,9 @@
       }
     },
     "rollup-plugin-scss": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-4.0.0.tgz",
-      "integrity": "sha512-wxasNXDYC2m+fDxCMgK00WebVWYmeFvShyNABmjvSJZ6D1/SepwqFeaMFMQromveI79gfvb64yJjiZZxSZxEIA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-scss/-/rollup-plugin-scss-3.0.0.tgz",
+      "integrity": "sha512-UldNaNHEon2a5IusHvj/Nnwc7q13YDvbFxz5pfNbHBNStxGoUNyM+0XwAA/UafJ1u8XRPGdBMrhWFthrrGZdWQ==",
       "requires": {
         "rollup-pluginutils": "^2.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "npm-run-all": "^4.1.5",
     "rollup": "^3.9.1",
     "rollup-plugin-copy": "^3.4.0",
-    "rollup-plugin-scss": "^4.0.0",
+    "rollup-plugin-scss": "^3.0.0",
     "sass": "^1.57.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Reverts design-history/prototype#26

This release does not include a changelog and is causing the Sass to fail to build on the deployed Heroku app. I can't see any benefit in updating to the latest version.